### PR TITLE
Updating default options to list to be compatible with click update

### DIFF
--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -108,13 +108,13 @@ def make_flask_app(config, username, password, url_prefix, compatibility_mode=Tr
 @click.option(
     "-u",
     "--redis-url",
-    default=None,
+    default=[],
     multiple=True,
     help="Redis URL. Can be specified multiple times. Default: redis://127.0.0.1:6379",
 )
 @click.option(
     "--redis-sentinels",
-    default=None,
+    default=[],
     hidden=True,
     help="[DEPRECATED] List of redis sentinels. Use --redis-url instead",
 )
@@ -134,7 +134,7 @@ def make_flask_app(config, username, password, url_prefix, compatibility_mode=Tr
 )
 @click.option(
     "--extra-path",
-    default=".",
+    default=["."],
     multiple=True,
     help="Append specified directories to sys.path",
 )
@@ -146,7 +146,7 @@ def make_flask_app(config, username, password, url_prefix, compatibility_mode=Tr
 )
 @click.option(
     "--delete-jobs",
-    default=None,
+    default=[],
     hidden=True,
     help="[DEPRECATED] Delete jobs instead of cancel",
 )


### PR DESCRIPTION
## Update Default Click Options

### Description
Updated default settings for click options so dashboard can be run.
- *Category*: Bugfix
- *JIRA issue*:  [MIC-2934](https://jira.ihme.washington.edu/browse/MIC-2934)
- *Research reference*: NA

Changed default click options from None to empty list [] for options that can be specified multiple times.

### Verification and Testing
Ran parallel simulations.

